### PR TITLE
Use only the server part of URL when adding a VSTS reference.

### DIFF
--- a/source/com.microsoft.tfs.client.common.ui/src/com/microsoft/tfs/client/common/ui/controls/connect/AddServerControl.java
+++ b/source/com.microsoft.tfs.client.common.ui/src/com/microsoft/tfs/client/common/ui/controls/connect/AddServerControl.java
@@ -229,6 +229,11 @@ public class AddServerControl extends BaseControl implements Validatable {
 
                 /* Make sure this is a complete URI. */
                 if (serverURI.getHost() != null) {
+
+                    if (ServerURIUtils.isHosted(serverURI)) {
+                        serverURI = URIUtils.newURI(serverURI.getScheme(), serverURI.getAuthority(), null, null, null);
+                    }
+
                     SWTUtil.setCompositeEnabled(connectionDetailsGroup, false);
                     previewText.setText(serverURI.toString());
 


### PR DESCRIPTION
Allow the user to paste to the Add Server page the URL copied from the repo page on VSTS WA. 