### PR TITLE
Fixing bug to enable Next button with no existing connection

### DIFF
--- a/source/com.microsoft.tfs.client.common.ui/src/com/microsoft/tfs/client/common/ui/wizard/common/WizardServerSelectionPage.java
+++ b/source/com.microsoft.tfs.client.common.ui/src/com/microsoft/tfs/client/common/ui/wizard/common/WizardServerSelectionPage.java
@@ -90,7 +90,7 @@ public class WizardServerSelectionPage extends ExtendedWizardPage {
             }
         });
 
-        setPageComplete(false);
+        setPageComplete(serverTypeSelectControl.getServer() != null);
     }
 
     @Override


### PR DESCRIPTION
I didn't file an issue for this bug. I was bashing on the product today to make sure it was still in good shape and this is the only bug I found. This was a regression caused by one of my changes this week.