### PR TITLE
Improve credentials experience.

### DIFF
--- a/source/com.microsoft.tfs.client.common.ui/src/com/microsoft/tfs/client/common/ui/dialogs/connect/ACSCredentialsDialog.java
+++ b/source/com.microsoft.tfs.client.common.ui/src/com/microsoft/tfs/client/common/ui/dialogs/connect/ACSCredentialsDialog.java
@@ -604,12 +604,12 @@ public class ACSCredentialsDialog extends CredentialsCompleteDialog {
         @Override
         protected URI getSignInURI(final URI serverSigninURL) {
             final Map<String, String> queryParameters = new HashMap<String, String>();
-            queryParameters.put("realm", URIUtils.VSTS_ROOT_URL_STRING); //$NON-NLS-1$
+            queryParameters.put("realm", URIUtils.TFS_REALM_URL_STRING); //$NON-NLS-1$
             queryParameters.put("protocol", "javascriptnotify"); //$NON-NLS-1$ //$NON-NLS-2$
             queryParameters.put("force", "1"); //$NON-NLS-1$ //$NON-NLS-2$
             queryParameters.put("compact", "1"); //$NON-NLS-1$ //$NON-NLS-2$
 
-            return URIUtils.addQueryParameters(URIUtils.newURI(URIUtils.TFS_REALM_URL_STRING), queryParameters);
+            return URIUtils.addQueryParameters(URIUtils.newURI(URIUtils.VSTS_ROOT_SIGNIN_URL_STRING), queryParameters);
         }
     }
 }

--- a/source/com.microsoft.tfs.client.eclipse.ui.egit/src/com/microsoft/tfs/client/eclipse/ui/egit/importwizard/WizardCrossCollectionRepoSelectionPage.java
+++ b/source/com.microsoft.tfs.client.eclipse.ui.egit/src/com/microsoft/tfs/client/eclipse/ui/egit/importwizard/WizardCrossCollectionRepoSelectionPage.java
@@ -121,6 +121,22 @@ public class WizardCrossCollectionRepoSelectionPage extends WizardCrossCollectio
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean canFlipToNextPage() {
+        if (super.canFlipToNextPage()) {
+            final CrossCollectionRepositoryInfo info = repositorySelectControl.getSelectedRepository();
+            final String workingDirectory = repositorySelectControl.getWorkingDirectory();
+
+            return info != null && !StringUtil.isNullOrEmpty(workingDirectory);
+
+        } else {
+            return false;
+        }
+    }
+
     @Override
     protected void clearList() {
         repos.clear();

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/CookieCredentials.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/CookieCredentials.java
@@ -3,7 +3,9 @@
 
 package com.microsoft.tfs.core.httpclient;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Credentials that are sent as Cookie headers.
@@ -25,6 +27,38 @@ public class CookieCredentials extends Credentials {
         }
 
         this.cookies = cookies;
+    }
+
+    /*
+     * Clones the original {@link CookieCredentials} but replaces the included
+     * cookies' domain with the specified value.
+     */
+    public CookieCredentials setDomain(final String domain) {
+        final List<Cookie> newCookies = new ArrayList<Cookie>(cookies.length);
+
+        for (final Cookie cookie : cookies) {
+            final Cookie newCookie =
+                new Cookie(domain, cookie.getName(), cookie.getValue(), "/", null, cookie.getSecure());
+            /*
+             * Setting the following property to true makes cookies added to the
+             * HTTP headers contain the attribute $Path=/ and thus a semicolon
+             * between the cookie value and this attribute.
+             *
+             * This is a workaround for a bug in cookie processing on the server
+             * side: the cookie values has to be appended with a semicolon
+             * otherwise an error is reported either by .NET or TFS (not clear
+             * yet by which one exactly):
+             *
+             * "The input is not a valid Base-64 string as it contains a
+             * non-base 64 character, more than two padding characters, or an
+             * illegal character among the padding characters."
+             */
+            newCookie.setPathAttributeSpecified(true);
+
+            newCookies.add(newCookie);
+        }
+
+        return new CookieCredentials(newCookies.toArray(new Cookie[cookies.length]));
     }
 
     public Cookie[] getCookies() {

--- a/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/CredentialsManager.java
+++ b/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/CredentialsManager.java
@@ -75,23 +75,6 @@ public interface CredentialsManager {
     CachedCredentials getCredentials(URI serverURI);
 
     /**
-     * Provides the credentials for the given {@link URI}. The given {@link URI}
-     * may be a TFS server, an HTTP proxy or a TFS proxy.
-     * <p>
-     * This method may return {@link CachedCredentials} that match only some
-     * parts of the given {@link URI} (instead of all parts).
-     *
-     * @param serverURI
-     *        The URI to connect to (never <code>null</code>)
-     * @param useRootVstsCredentials
-     *        Allow to use root VSTS credentials (i.e. credentials for
-     *        https://app.vssps.visualstudio.com) if the exact serverURI
-     *        credentials were not found.
-     * @return The credentials to connect with (never <code>null</code>)
-     */
-    CachedCredentials getCredentials(URI serverURI, boolean useRootVstsCredentials);
-
-    /**
      * Sets the credentials for the given {@link URI}. The given {@link URI} may
      * be a TFS server, an HTTP proxy or a TFS proxy.
      * <p>

--- a/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/internal/KeychainCredentialsManager.java
+++ b/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/internal/KeychainCredentialsManager.java
@@ -63,11 +63,6 @@ public class KeychainCredentialsManager implements CredentialsManager {
         return null;
     }
 
-    @Override
-    public CachedCredentials getCredentials(URI serverURI, boolean useRootVstsCredentials) {
-        return getCredentials(serverURI);
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/internal/NullCredentialsManager.java
+++ b/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/internal/NullCredentialsManager.java
@@ -47,11 +47,6 @@ public class NullCredentialsManager implements CredentialsManager {
         return null;
     }
 
-    @Override
-    public CachedCredentials getCredentials(URI serverURI, boolean useRootVstsCredentials) {
-        return getCredentials(serverURI);
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/internal/PersistenceStoreCredentialsManager.java
+++ b/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/internal/PersistenceStoreCredentialsManager.java
@@ -75,11 +75,6 @@ public class PersistenceStoreCredentialsManager implements CredentialsManager {
         return credentials.toArray(new CachedCredentials[credentials.size()]);
     }
 
-    @Override
-    public CachedCredentials getCredentials(URI serverURI, boolean useRootVstsCredentials) {
-        return getCredentials(serverURI);
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/internal/WinCredentialsManager.java
+++ b/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/internal/WinCredentialsManager.java
@@ -53,11 +53,6 @@ public class WinCredentialsManager implements CredentialsManager {
         return null;
     }
 
-    @Override
-    public CachedCredentials getCredentials(URI serverURI, boolean useRootVstsCredentials) {
-        return getCredentials(serverURI);
-    }
-
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Fixed Bug 550494 - TEE: Sign in page sometimes redirects to the "Create your site URL" page instead of finishing sign in

Fixed few bugs including:
- Bug 550494 - TEE: Sign in page sometimes redirects to the "Create your site URL" page instead of finishing sign in

Got rid of global PATs. There was a bug related to saved global PAT that allowed to use a PAT of one user as a PAT of another one. Having in mind that global PATs are going to retire soon, it would be better not to use them in this release.

The logic of CookieRedentials usage across multiple VSTS accounts has been improved.

Added Credentials and improved PAT validation methods in the TEE REST client.

Some code optimization done in the CredentialsManager. The recently added optional parameter removed from the getCredentials method. It has been used for global PATs only.

The "Next" button's enablement improved on Cross Collection pages.

After all these changes I cannot anymore reproduce the Bug 548491 - TEE: Work Items: 401 trying to create a bug. I hope it's fixed as well.