### PR TITLE
Move away from using global PAT

### DIFF
--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/CLCTransportRequestHandler.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/CLCTransportRequestHandler.java
@@ -170,17 +170,18 @@ public class CLCTransportRequestHandler extends DefaultTransportRequestHandler {
         }
 
         // Prompt for all fields regardless of old credentials
-        UsernamePasswordCredentials newCredentials = null;  
+        UsernamePasswordCredentials newCredentials = null;
         if (Prompt.interactiveLoginAllowed() && ServerURIUtils.isHosted(service.getEndpoint())) {
             /*
-             * If we are making request against hosted services, attempt to recreate the oauth2 token 
-             * or pat. 
+             * If we are making request against hosted services, attempt to
+             * recreate the oauth2 token or pat.
              */
             newCredentials = Prompt.getCredentialsInteractively(display, persistCredentials);
         }
-        
+
         if (newCredentials == null) {
-            // If there is no creds for team services, then prompt (could be domain creds for TFS, or basic auth for VSTS)
+            // If there is no creds for team services, then prompt (could be
+            // domain creds for TFS, or basic auth for VSTS)
             newCredentials = Prompt.getCredentials(display, input, null, null);
         }
 

--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/CLCTransportRequestHandler.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/CLCTransportRequestHandler.java
@@ -176,7 +176,7 @@ public class CLCTransportRequestHandler extends DefaultTransportRequestHandler {
              * If we are making request against hosted services, attempt to
              * recreate the oauth2 token or pat.
              */
-            newCredentials = Prompt.getCredentialsInteractively(display, persistCredentials);
+            newCredentials = Prompt.getCredentialsInteractively(service.getEndpoint(), display, persistCredentials);
         }
 
         if (newCredentials == null) {

--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/commands/Command.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/commands/Command.java
@@ -1553,11 +1553,12 @@ public abstract class Command
                 new UsernamePasswordCredentials(cachedCredentials.getUsername(), cachedCredentials.getPassword());
         } else {
             /*
-            * For TFS instance, validate will test whether Kerberos is available and the user
-            * has a ticket and prompt for username/pass/domain if not.
-            * 
-            * For VSTS instance, do interactive auth if allow prompt
-            */
+             * For TFS instance, validate will test whether Kerberos is
+             * available and the user has a ticket and prompt for
+             * username/pass/domain if not.
+             * 
+             * For VSTS instance, do interactive auth if allow prompt
+             */
             credentials = ServerURIUtils.isHosted(serverURI) ? null : new DefaultNTCredentials();
         }
 
@@ -1565,9 +1566,9 @@ public abstract class Command
          * This method checks the credentials we've read already, prompts if
          * allowed for missing ones, or lets defaults kick in.
          */
-        log.debug("credentialsManager.canWrite(): " + credentialsManager.canWrite());  //$NON-NLS-1$
-        log.debug("persistCredentials(): " + persistCredentials());; //$NON-NLS-1$
-        
+        log.debug("credentialsManager.canWrite(): " + credentialsManager.canWrite()); //$NON-NLS-1$
+        log.debug("persistCredentials(): " + persistCredentials()); //$NON-NLS-1$
+
         credentials =
             validateCredentials(serverURI, credentials, credentialsManager.canWrite() && persistCredentials());
 
@@ -1653,21 +1654,25 @@ public abstract class Command
              * Defensively create a DefaultNTCredentials so we do not throw NPE
              */
             credentials = new DefaultNTCredentials();
-           
+
             if (Prompt.interactiveLoginAllowed() && ServerURIUtils.isHosted(serverURI) && prompt) {
-                log.debug("Request against VisualStudio Team Services and credential is not available, try OAuth2 flow."); //$NON-NLS-1$
+                log.debug(
+                    "Request against VisualStudio Team Services and credential is not available, try OAuth2 flow."); //$NON-NLS-1$
                 /*
-                 * Interactive auth for team services when there is no cred presented
+                 * Interactive auth for team services when there is no cred
+                 * presented
                  */
-                final UsernamePasswordCredentials cred = Prompt.getCredentialsInteractively(display, persistCredentials);
+                final UsernamePasswordCredentials cred =
+                    Prompt.getCredentialsInteractively(display, persistCredentials);
                 if (cred != null) {
                     log.debug("Retrieved a credential interactively from OAuth2 flow."); //$NON-NLS-1$
                     credentials = cred;
                 } else {
-                    log.debug("Failed to retrieve any credential, did user close the browser or JavaFx failed to load?"); //$NON-NLS-1$
+                    log.debug(
+                        "Failed to retrieve any credential, did user close the browser or JavaFx failed to load?"); //$NON-NLS-1$
                 }
-            } 
-            
+            }
+
         }
 
         if (credentials instanceof UsernamePasswordCredentials) {

--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/commands/Command.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/commands/Command.java
@@ -1663,7 +1663,7 @@ public abstract class Command
                  * presented
                  */
                 final UsernamePasswordCredentials cred =
-                    Prompt.getCredentialsInteractively(display, persistCredentials);
+                    Prompt.getCredentialsInteractively(serverURI, display, persistCredentials);
                 if (cred != null) {
                     log.debug("Retrieved a credential interactively from OAuth2 flow."); //$NON-NLS-1$
                     credentials = cred;

--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/prompt/Prompt.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/prompt/Prompt.java
@@ -45,7 +45,7 @@ import com.microsoft.tfs.util.Check;
 public final class Prompt {
 
     private static final Log log = LogFactory.getLog(Prompt.class);
-    
+
     /**
      * Constants for OAuth2 Interactive Browser logon flow
      */
@@ -198,7 +198,7 @@ public final class Prompt {
 
         return new UsernamePasswordCredentials(username, password);
     }
-    
+
     /**
      * Makes an {@link UsernamePasswordCredentials} from OAuth2 flow
      * 
@@ -206,20 +206,20 @@ public final class Prompt {
      * 
      * @param display
      *        the display to use (must not be <code>null</code>)
-     *        
-     * @param persistCredentials 
-     *       caller intend to persist the retrieved credential 
-     *        
+     * 
+     * @param persistCredentials
+     *        caller intend to persist the retrieved credential
+     * 
      * @return an {@link UsernamePasswordCredentials} object or
-     *         <code>null</code> if there was an error retrieving the credential 
-     *         from OAuth2 flow. (for example, user closed the browser, or is running
-     *         on a Java runtime that does not support JavaFx)
+     *         <code>null</code> if there was an error retrieving the credential
+     *         from OAuth2 flow. (for example, user closed the browser, or is
+     *         running on a Java runtime that does not support JavaFx)
      */
     public static UsernamePasswordCredentials getCredentialsInteractively(
-        final Display display, 
+        final Display display,
         final boolean persistCredentials) {
         Check.notNull(display, "display"); //$NON-NLS-1$
-        
+
         log.debug("Interactively retrieving credential based on oauth2 flow"); //$NON-NLS-1$
         final SecretStore<TokenPair> accessTokenStore = new InsecureInMemoryStore<TokenPair>();
         final SecretStore<Token> tokenStore = new InsecureInMemoryStore<Token>();
@@ -232,8 +232,7 @@ public final class Prompt {
             /*
              * If this credential is to be persisted, then let's create a PAT
              */
-            authenticator = new VstsPatAuthenticator(CLIENT_ID, REDIRECT_URL,
-                accessTokenStore, tokenStore);
+            authenticator = new VstsPatAuthenticator(CLIENT_ID, REDIRECT_URL, accessTokenStore, tokenStore);
             options.patGenerationOptions.displayName = getPATDisplayName();
 
         } else {
@@ -241,24 +240,29 @@ public final class Prompt {
             /*
              * Not persisting this credential, simply create an oauth2 token
              */
-            authenticator = new OAuth2Authenticator(OAuth2Authenticator.MANAGEMENT_CORE_RESOURCE, CLIENT_ID,
-                URI.create(REDIRECT_URL), accessTokenStore);
+            authenticator = new OAuth2Authenticator(
+                OAuth2Authenticator.MANAGEMENT_CORE_RESOURCE,
+                CLIENT_ID,
+                URI.create(REDIRECT_URL),
+                accessTokenStore);
         }
 
         final UserPasswordCredentialProvider provider = new UserPasswordCredentialProvider(authenticator);
 
         try {
             final Credential tokenCreds = provider.getVstsGlobalCredentials(PromptBehavior.AUTO, options);
-            
-            return new UsernamePasswordCredentials(tokenCreds.Username, tokenCreds.Password);            
-            
+
+            return new UsernamePasswordCredentials(tokenCreds.Username, tokenCreds.Password);
+
         } catch (final Exception e) {
             /*
-             *  Catching all exceptions because I do not want to stop the flow at all cases.  There are
-             *  always fallback mechanism that we should try.  Simply log the error.
-             *  
-             *  For example, oauth2-useragent will throw IllegalStateException if it could not find a suitable 
-             *  provider with clear error message, or AuthorizationException if we failed to login successfully.  
+             * Catching all exceptions because I do not want to stop the flow at
+             * all cases. There are always fallback mechanism that we should
+             * try. Simply log the error.
+             * 
+             * For example, oauth2-useragent will throw IllegalStateException if
+             * it could not find a suitable provider with clear error message,
+             * or AuthorizationException if we failed to login successfully.
              */
             log.debug(e.getMessage());
 
@@ -268,24 +272,24 @@ public final class Prompt {
         // Failed to get credential, return null
         return null;
     }
-    
+
     /**
-     * @return <code>true</code> by default
-     *         <code>false</code> if user explicitly disables browser interactive login 
+     * @return <code>true</code> by default <code>false</code> if user
+     *         explicitly disables browser interactive login
      */
     public static boolean interactiveLoginAllowed() {
         return !EnvironmentVariables.getBoolean(EnvironmentVariables.BYPASS_INTERACTIVE_BROWSER_LOGIN, false);
     }
-    
+
     private static String getPATDisplayName() {
         // following IntelliJ Plugin's format
         final String formatter = "TF from: %s on: %s"; //$NON-NLS-1$
         final String machineName = LocalHost.getShortName();
-        
+
         final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss"); //$NON-NLS-1$
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC")); //$NON-NLS-1$
         final String time = dateFormat.format(new Date());
- 
+
         return String.format(formatter, machineName, time);
     }
 

--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/prompt/Prompt.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/prompt/Prompt.java
@@ -216,11 +216,13 @@ public final class Prompt {
      *         running on a Java runtime that does not support JavaFx)
      */
     public static UsernamePasswordCredentials getCredentialsInteractively(
+        final URI serverURI,
         final Display display,
         final boolean persistCredentials) {
         Check.notNull(display, "display"); //$NON-NLS-1$
+        Check.notNull(serverURI, "serverURI"); //$NON-NLS-1$
 
-        log.debug("Interactively retrieving credential based on oauth2 flow"); //$NON-NLS-1$
+        log.debug("Interactively retrieving credential based on oauth2 flow for " + serverURI.toString()); //$NON-NLS-1$
         final SecretStore<TokenPair> accessTokenStore = new InsecureInMemoryStore<TokenPair>();
         final SecretStore<Token> tokenStore = new InsecureInMemoryStore<Token>();
 
@@ -250,7 +252,7 @@ public final class Prompt {
         final UserPasswordCredentialProvider provider = new UserPasswordCredentialProvider(authenticator);
 
         try {
-            final Credential tokenCreds = provider.getVstsGlobalCredentials(PromptBehavior.AUTO, options);
+            final Credential tokenCreds = provider.getSpecificCredentialFor(serverURI, PromptBehavior.AUTO, options);
 
             return new UsernamePasswordCredentials(tokenCreds.Username, tokenCreds.Password);
 


### PR DESCRIPTION
Generate account level PAT if we are using PATs, that is
if user has opt in to save the interactive credential.

And plus Eclipse auto-formatted the code upon saving -- this is to make the code confirm to our code style, so I guess the change is all good.  