### PR TITLE
Maintain LF-only line endings of clc-launcher through Windows builds

### DIFF
--- a/source/com.microsoft.tfs.client.clc/scripts/.gitattributes
+++ b/source/com.microsoft.tfs.client.clc/scripts/.gitattributes
@@ -1,0 +1,5 @@
+# Maintain LF-only line endings on clc-launcher despite other Git configuration.
+# This allows the LF-only line endings to be maintained through Windows-based build processes
+# so that the script can still run on Linux and Mac where the LF-only line endings are required
+# for execution.
+clc-launcher text eol=lf


### PR DESCRIPTION
During the process of building the CLC on Windows, it was checking out clc-launcher with core.autocrlf=true.  This replaced LF line endings with CRLF and kept it that way in the release package.  LF-only line endings are necessary for this file, later renamed to 'tf', to be executed on Linux and Mac OS.  This .gitattributes file forces maintenance of LF-only line endings of clc-launcher through Windows builds for subsequent execution on Linux and Mac OS.