### PR TITLE
Connecting to VSTS root re-use the original connection advisor.

### DIFF
--- a/source/com.microsoft.tfs.client.common/src/com/microsoft/tfs/client/common/credentials/CredentialsHelper.java
+++ b/source/com.microsoft.tfs.client.common/src/com/microsoft/tfs/client/common/credentials/CredentialsHelper.java
@@ -157,7 +157,7 @@ public abstract class CredentialsHelper {
         final TFSConnection vstsConnection = new TFSTeamProjectCollection(
             URIUtils.VSTS_ROOT_URL,
             getVstsRootCredentials(connection),
-            new CommonClientConnectionAdvisor(Locale.getDefault(), TimeZone.getDefault()));
+            connection.getConnectionAdvisor());
 
         return vstsConnection;
     }

--- a/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/TFSConnection.java
+++ b/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/TFSConnection.java
@@ -1375,7 +1375,7 @@ public abstract class TFSConnection implements Closable {
         return instanceData.getCredentialsHolder();
     }
 
-    protected ConnectionAdvisor getConnectionAdvisor() {
+    public ConnectionAdvisor getConnectionAdvisor() {
         checkNotClosed();
         return advisor;
     }


### PR DESCRIPTION
That ensures that correct proxy settings are used.