### PR TITLE
fix git clone to checkout default branch

### DIFF
--- a/source/com.microsoft.tfs.client.eclipse.ui/src/com/microsoft/tfs/client/eclipse/ui/wizard/importwizard/support/ImportGitRepository.java
+++ b/source/com.microsoft.tfs.client.eclipse.ui/src/com/microsoft/tfs/client/eclipse/ui/wizard/importwizard/support/ImportGitRepository.java
@@ -92,7 +92,7 @@ public class ImportGitRepository extends ImportItemBase implements Comparable<Im
                 branches[idx] = name;
                 refs[idx] = fullName;
 
-                if (name.equals(gitRepositoryJson.getDefaultBranch())) {
+                if (fullName.equals(gitRepositoryJson.getDefaultBranch())) {
                     defaultBranch = name;
                     defaultRef = fullName;
                 }


### PR DESCRIPTION
the first alphabetical branch was being checked out by default before rather than the default branch.