### PR TITLE
Bug #600362 - TEE: TFS Import wizard (SCE>Import>...) ignores folder selection in SCE

### DIFF
--- a/source/com.microsoft.tfs.client.eclipse.ui/src/com/microsoft/tfs/client/eclipse/ui/wizard/importwizard/TfsImportWizard.java
+++ b/source/com.microsoft.tfs.client.eclipse.ui/src/com/microsoft/tfs/client/eclipse/ui/wizard/importwizard/TfsImportWizard.java
@@ -38,7 +38,9 @@ public class TfsImportWizard extends ImportWizard {
         final IWizardPage nextConnectionPage = getNextConnectionPage();
 
         if (nextConnectionPage != null) {
-            return nextConnectionPage;
+            if (!nextConnectionPage.getName().equals(getSelectionPageName()) || !skipCrossSelectionPage()) {
+                return nextConnectionPage;
+            }
         }
 
         if (!hasPageData(Workspace.class)) {
@@ -54,6 +56,11 @@ public class TfsImportWizard extends ImportWizard {
         }
 
         return null;
+    }
+
+    private boolean skipCrossSelectionPage() {
+        ImportOptions options = (ImportOptions) getPageData(ImportOptions.class);
+        return options.getImportFolders().length > 0;
     }
 
     @Override


### PR DESCRIPTION
In case the TFS Import Wizard is invoked from the Source Control Explorer as a context menu action for a folder, the wizard's PageData(ImportOptions) is prepopulated with the folder path that includes the project name as well. We do not need to show the project selection page in this case.