### PR TITLE
Explicitly specify the "UTF-8" encoding for all SOAP XML processing.

### DIFF
--- a/source/com.microsoft.tfs.core.ws.runtime/src/com/microsoft/tfs/core/ws/runtime/client/SOAPRequestEntity11.java
+++ b/source/com.microsoft.tfs.core.ws.runtime/src/com/microsoft/tfs/core/ws/runtime/client/SOAPRequestEntity11.java
@@ -50,7 +50,7 @@ public class SOAPRequestEntity11 extends SOAPRequestEntity {
         try {
             writer = getXMLOutputFactory().createXMLStreamWriter(
                 new BufferedOutputStream(out),
-                SOAPRequestEntity12.SOAP_ENCODING);
+                SOAPRequestEntity.SOAP_ENCODING);
 
             writer.writeStartDocument();
             writer.writeStartElement("soap", "Envelope", Schemas.SOAP_11); //$NON-NLS-1$ //$NON-NLS-2$

--- a/source/com.microsoft.tfs.core.ws.runtime/src/com/microsoft/tfs/core/ws/runtime/client/SOAPRequestEntity12.java
+++ b/source/com.microsoft.tfs.core.ws.runtime/src/com/microsoft/tfs/core/ws/runtime/client/SOAPRequestEntity12.java
@@ -50,7 +50,7 @@ public class SOAPRequestEntity12 extends SOAPRequestEntity {
         try {
             writer = getXMLOutputFactory().createXMLStreamWriter(
                 new BufferedOutputStream(out),
-                SOAPRequestEntity12.SOAP_ENCODING);
+                SOAPRequestEntity.SOAP_ENCODING);
 
             writer.writeStartDocument();
             writer.writeStartElement("soap", "Envelope", Schemas.SOAP_12); //$NON-NLS-1$ //$NON-NLS-2$

--- a/source/com.microsoft.tfs.core.ws.runtime/src/com/microsoft/tfs/core/ws/runtime/client/SOAPService.java
+++ b/source/com.microsoft.tfs.core.ws.runtime/src/com/microsoft/tfs/core/ws/runtime/client/SOAPService.java
@@ -392,14 +392,14 @@ public abstract class SOAPService {
         final SOAPRequest request,
         final String responseName,
         final SOAPMethodResponseReader responseReader)
-            throws SOAPFault,
-                UnauthorizedException,
-                ProxyUnauthorizedException,
-                FederatedAuthException,
-                InvalidServerResponseException,
-                EndpointNotFoundException,
-                TransportException,
-                TransportRequestHandlerCanceledException {
+        throws SOAPFault,
+            UnauthorizedException,
+            ProxyUnauthorizedException,
+            FederatedAuthException,
+            InvalidServerResponseException,
+            EndpointNotFoundException,
+            TransportException,
+            TransportRequestHandlerCanceledException {
         /*
          * Duplicate the transport request handler map so we needn't keep a lock
          * and so that we have a consistent set throughout execution.
@@ -496,13 +496,13 @@ public abstract class SOAPService {
         final SOAPRequest request,
         final String responseName,
         final SOAPMethodResponseReader responseReader)
-            throws SOAPFault,
-                UnauthorizedException,
-                ProxyUnauthorizedException,
-                InvalidServerResponseException,
-                EndpointNotFoundException,
-                TransportException,
-                CanceledException {
+        throws SOAPFault,
+            UnauthorizedException,
+            ProxyUnauthorizedException,
+            InvalidServerResponseException,
+            EndpointNotFoundException,
+            TransportException,
+            CanceledException {
         final PostMethod method = request.getPostMethod();
 
         final long start = System.currentTimeMillis();
@@ -582,8 +582,9 @@ public abstract class SOAPService {
 
                     try {
 
-                        // responseStream = method.getResponseBodyAsStream();
-                        reader = SOAPService.xmlInputFactory.createXMLStreamReader(responseStream);
+                        reader = SOAPService.xmlInputFactory.createXMLStreamReader(
+                            responseStream,
+                            SOAPRequestEntity.SOAP_ENCODING);
 
                         /*
                          * Read as far as the SOAP body from the stream.

--- a/source/com.microsoft.tfs.core.ws.runtime/src/com/microsoft/tfs/core/ws/runtime/types/StaxAnyContentType.java
+++ b/source/com.microsoft.tfs.core.ws.runtime/src/com/microsoft/tfs/core/ws/runtime/types/StaxAnyContentType.java
@@ -19,6 +19,7 @@ import javax.xml.stream.XMLStreamWriter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.microsoft.tfs.core.ws.runtime.client.SOAPRequestEntity;
 import com.microsoft.tfs.core.ws.runtime.stax.StaxFactoryProvider;
 import com.microsoft.tfs.core.ws.runtime.stax.StaxUtils;
 import com.microsoft.tfs.util.Closable;
@@ -67,7 +68,8 @@ public class StaxAnyContentType implements AnyContentType {
                 final InputStream inputStream = ftos.getInputStream();
                 tempInputStreams.add(inputStream);
 
-                final XMLStreamReader reader = inputFactory.createXMLStreamReader(inputStream);
+                final XMLStreamReader reader =
+                    inputFactory.createXMLStreamReader(inputStream, SOAPRequestEntity.SOAP_ENCODING);
 
                 return reader;
             } catch (final IOException e) {
@@ -205,7 +207,9 @@ public class StaxAnyContentType implements AnyContentType {
                     /*
                      * Create a writer.
                      */
-                    writer = StaxFactoryProvider.getXMLOutputFactory().createXMLStreamWriter(ftos);
+                    writer = StaxFactoryProvider.getXMLOutputFactory().createXMLStreamWriter(
+                        ftos,
+                        SOAPRequestEntity.SOAP_ENCODING);
                     writer.writeStartDocument();
 
                     StaxUtils.copyCurrentElement(reader, writer);


### PR DESCRIPTION
The main change is in that couple places in SOAP XML processing missed an explicit encoding specification. It looks like after we've switched to a new STaX implementation (the standard JRE one instead of obsolete third party library), the way how the default encoding is determined for XML reader and XML writer have changed.