### PR TITLE
Rename the prefix when saving PATs in GNOME Keyring

### DIFF
--- a/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/internal/GnomeKeyringCredentialsManager.java
+++ b/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/credentials/internal/GnomeKeyringCredentialsManager.java
@@ -135,7 +135,7 @@ public class GnomeKeyringCredentialsManager implements CredentialsManager {
     }
 
     private String getKey(final URI serverURI) {
-        return Secret.DefaultUriNameConversion.convert(serverURI, "tee_clc"); //$NON-NLS-1$
+        return Secret.DefaultUriNameConversion.convert(serverURI, "tee"); //$NON-NLS-1$
     }
 
 }


### PR DESCRIPTION
This is because this class is used by both CLC as well as the Eclipse
plugin.  This change means any private TEE 14.0.4 build will need to
re-authenticate after upgrade.  However otherwise this prefix is
incorrect.