### PR TITLE
bug #669559 - TEE: The UIHelpers#runOnUIThread method can throw

### DIFF
--- a/source/com.microsoft.tfs.client.common.ui/src/com/microsoft/tfs/client/common/ui/framework/helper/UIHelpers.java
+++ b/source/com.microsoft.tfs.client.common.ui/src/com/microsoft/tfs/client/common/ui/framework/helper/UIHelpers.java
@@ -190,7 +190,9 @@ public class UIHelpers {
      *        the Runnable to run
      */
     public static void runOnUIThread(final Shell shell, final boolean asynch, final Runnable runnable) {
-        runOnUIThread(shell.getDisplay(), asynch, runnable);
+        if (!shell.isDisposed()) {
+            runOnUIThread(shell.getDisplay(), asynch, runnable);
+        }
     }
 
     /**


### PR DESCRIPTION
 an exception if the shell passed as a parameter is disposed.