### PR TITLE
Adding the ability to disable telemetry with env var or system property

### DIFF
--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/Application.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/Application.java
@@ -147,6 +147,10 @@ public abstract class Application implements AbstractConsoleApplication {
          */
         ProductInformation.initialize(ProductName.CLC);
 
+        // We need to check for the disable telemetry flag before we send any
+        // telemetry to the server
+        TfsTelemetryHelper.checkDisableTelemetryProperty();
+
         TfsTelemetryHelper.sendSessionBegins();
         final int ret = run(args, false);
         TfsTelemetryHelper.sendSessionEnds();
@@ -252,7 +256,7 @@ public abstract class Application implements AbstractConsoleApplication {
              * arguments.
              */
 
-            AtomicReference<Exception> outException = new AtomicReference<Exception>();
+            final AtomicReference<Exception> outException = new AtomicReference<Exception>();
             c = parseTokens(args, options, freeArguments, outException);
 
             /*
@@ -485,7 +489,7 @@ public abstract class Application implements AbstractConsoleApplication {
 
                 try {
                     o = optionsMap.findOption(token);
-                } catch (InvalidOptionValueException e) {
+                } catch (final InvalidOptionValueException e) {
                     outException.set(e);
                     break;
                 }

--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/Application.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/Application.java
@@ -41,7 +41,6 @@ import com.microsoft.tfs.core.exceptions.TFSFederatedAuthException;
 import com.microsoft.tfs.core.httpclient.auth.AuthenticationSecurityException;
 import com.microsoft.tfs.core.product.ProductInformation;
 import com.microsoft.tfs.core.product.ProductName;
-import com.microsoft.tfs.core.telemetry.TfsTelemetryHelper;
 import com.microsoft.tfs.core.ws.runtime.exceptions.ProxyException;
 import com.microsoft.tfs.util.Check;
 import com.microsoft.tfs.util.StringUtil;
@@ -147,13 +146,13 @@ public abstract class Application implements AbstractConsoleApplication {
          */
         ProductInformation.initialize(ProductName.CLC);
 
-        // We need to check for the disable telemetry flag before we send any
+        // We need to check for the no telemetry flag before we send any
         // telemetry to the server
-        TfsTelemetryHelper.checkDisableTelemetryProperty();
+        CLCTelemetryHelper.checkNoTelemetryProperty();
 
-        TfsTelemetryHelper.sendSessionBegins();
+        CLCTelemetryHelper.sendSessionBegins();
         final int ret = run(args, false);
-        TfsTelemetryHelper.sendSessionEnds();
+        CLCTelemetryHelper.sendSessionEnds();
 
         return ret;
     }
@@ -340,7 +339,7 @@ public abstract class Application implements AbstractConsoleApplication {
              * Same as above but returned by some low level Core or Common
              * classes, e.g. HttpHost.
              */
-            TfsTelemetryHelper.sendException(e);
+            CLCTelemetryHelper.sendException(e);
 
             final String messageFormat = Messages.getString("Application.AnArgumentErrorOccurredFormat"); //$NON-NLS-1$
             final String message = MessageFormat.format(messageFormat, e.getLocalizedMessage());
@@ -406,7 +405,7 @@ public abstract class Application implements AbstractConsoleApplication {
              * The most basic core exception class. All lower level (SOAP)
              * exceptions are wrapped in these.
              */
-            TfsTelemetryHelper.sendException(e);
+            CLCTelemetryHelper.sendException(e);
 
             final String messageFormat = Messages.getString("Application.AnErrorOccurredFormat"); //$NON-NLS-1$
             final String message = MessageFormat.format(messageFormat, e.getLocalizedMessage());
@@ -414,7 +413,7 @@ public abstract class Application implements AbstractConsoleApplication {
             display.printErrorLine(message);
             ret = ExitCode.FAILURE;
         } catch (final Throwable e) {
-            TfsTelemetryHelper.sendException(new Exception("Unexpected exception.", e)); //$NON-NLS-1$
+            CLCTelemetryHelper.sendException(new Exception("Unexpected exception.", e)); //$NON-NLS-1$
 
             log.error("Unexpected exception: ", e); //$NON-NLS-1$
         }

--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/EnvironmentVariables.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/EnvironmentVariables.java
@@ -84,6 +84,13 @@ public abstract class EnvironmentVariables {
     public static final String NO_SUMMARY = "TFSVC_NOSUMMARY"; //$NON-NLS-1$
 
     /**
+     * When set to any value, disables the sending of telemetry values.
+     * <p>
+     * IntelliJ uses this environment variable when calling the CLC.
+     */
+    public static final String NO_TELEMETRY = "TF_NOTELEMETRY"; //$NON-NLS-1$
+
+    /**
      * This environment variable is only used on Mac OS. When set to False, No
      * or N PersistanceCredentialsManager will be used to store credentials
      * instead of KeyChain
@@ -92,12 +99,12 @@ public abstract class EnvironmentVariables {
      * save credentials
      */
     public static final String USE_KEYCHAIN = "TF_USE_KEYCHAIN"; //$NON-NLS-1$
-    
+
     /**
      * This environment variable is used to disable the oauth2 interactive login
      * flow when we issue request against VSTS instances
      * <p>
-     * When set to False, we will bypass showing the browser to user. 
+     * When set to False, we will bypass showing the browser to user.
      */
     public static final String BYPASS_INTERACTIVE_BROWSER_LOGIN = "TF_BYPASS_BROWSER_LOGIN"; //$NON-NLS-1$
 
@@ -107,8 +114,8 @@ public abstract class EnvironmentVariables {
         if (StringUtil.isNullOrEmpty(value)) {
             return defaultValue;
         } else {
-            return !value.equalsIgnoreCase("FALSE") && //$NON-NLS-1$
-                !value.equalsIgnoreCase("NO") //$NON-NLS-1$
+            return !value.equalsIgnoreCase("FALSE") //$NON-NLS-1$
+                && !value.equalsIgnoreCase("NO") //$NON-NLS-1$
                 && !value.equalsIgnoreCase("N"); //$NON-NLS-1$
         }
     }

--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/telemetry/CLCTelemetryHelper.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/telemetry/CLCTelemetryHelper.java
@@ -14,6 +14,11 @@ import com.microsoft.tfs.core.telemetry.TfsTelemetryHelper;
 
 public class CLCTelemetryHelper extends TfsTelemetryHelper {
     public static void sendCommandFinishedEvent(final Command command, final int retCode) {
+        if (sendingTelemetryDisabled) {
+            // Don't send any telemetry
+            return;
+        }
+
         final String commandName;
         if (command == null) {
             commandName = "**UNKNOWN**"; //$NON-NLS-1$


### PR DESCRIPTION
These changes are needed to speed up the CLC when being called from an IDE like IntelliJ. It also gives the user a way to turn off telemetry.