### PR TITLE
Adding owner-display-name to the xml format of the Workspaces command

### DIFF
--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/vc/commands/CommandWorkspaces.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/vc/commands/CommandWorkspaces.java
@@ -557,6 +557,12 @@ public final class CommandWorkspaces extends Command {
 
             workspaceAttributes.addAttribute("", "", CommonXMLNames.NAME, "CDATA", workspace.getName()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             workspaceAttributes.addAttribute("", "", CommonXMLNames.OWNER, "CDATA", workspace.getOwnerName()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            workspaceAttributes.addAttribute(
+                "", //$NON-NLS-1$
+                "", //$NON-NLS-1$
+                CommonXMLNames.OWNER_DISPLAY_NAME,
+                "CDATA", //$NON-NLS-1$
+                workspace.getOwnerDisplayName());
             workspaceAttributes.addAttribute("", "", CommonXMLNames.COMPUTER, "CDATA", workspace.getComputer()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             workspaceAttributes.addAttribute("", "", CommonXMLNames.COMMENT, "CDATA", workspace.getComment()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
             workspaceAttributes.addAttribute(

--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/xml/CommonXMLNames.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/xml/CommonXMLNames.java
@@ -29,6 +29,7 @@ public class CommonXMLNames {
     public static final String FILE_TYPE = "file-type"; //$NON-NLS-1$
     public static final String USER = "user"; //$NON-NLS-1$
     public static final String OWNER = "owner"; //$NON-NLS-1$
+    public static final String OWNER_DISPLAY_NAME = "owner-display-name"; //$NON-NLS-1$
     public static final String COMMITTER = "committer"; //$NON-NLS-1$
     public static final String ITEM = "item"; //$NON-NLS-1$
     public static final String CHANGE_TYPE = "change-type"; //$NON-NLS-1$


### PR DESCRIPTION
This change to allow IntelliJ to display the owner of the workspace properly. The owner name which is currently available seems to come back as a guid sometimes.