### PR TITLE
Bug #687599

### DIFF
--- a/source/com.microsoft.tfs.client.eclipse.ui.egit/src/com/microsoft/tfs/client/eclipse/ui/egit/importwizard/GitImportWizardSelectFoldersPage.java
+++ b/source/com.microsoft.tfs.client.eclipse.ui.egit/src/com/microsoft/tfs/client/eclipse/ui/egit/importwizard/GitImportWizardSelectFoldersPage.java
@@ -205,6 +205,7 @@ public class GitImportWizardSelectFoldersPage extends ExtendedWizardPage {
         repositories = itemCollection.getRepositories();
 
         setFoldersInput();
+        setPageComplete(isValid());
     }
 
     private void setFoldersInput() {


### PR DESCRIPTION
The "Next" button on the "Select folders" page in the Git import wizard
is available without any folder selected.