### PR TITLE
Fixing NullReferenceException error when doing KeepYours

### DIFF
--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/vc/commands/CommandResolve.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/vc/commands/CommandResolve.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.microsoft.alm.client.utils.StringUtil;
 import com.microsoft.tfs.client.clc.AcceptedOptionSet;
 import com.microsoft.tfs.client.clc.EnvironmentVariables;
 import com.microsoft.tfs.client.clc.ExitCode;
@@ -203,8 +204,7 @@ public final class CommandResolve extends Command implements ConflictResolvedLis
          */
         boolean containsSymlink = false;
         for (final Conflict conflict : conflicts) {
-            if (conflict.getTargetLocalItem() != null
-                && conflict.getTargetLocalItem().length() > 0
+            if (!StringUtil.isNullOrEmpty(conflict.getTargetLocalItem())
                 && FileSystemUtils.getInstance().getAttributes(conflict.getTargetLocalItem()).isSymbolicLink()) {
                 containsSymlink = true;
                 break;

--- a/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/vc/commands/CommandResolve.java
+++ b/source/com.microsoft.tfs.client.clc/src/com/microsoft/tfs/client/clc/vc/commands/CommandResolve.java
@@ -203,7 +203,9 @@ public final class CommandResolve extends Command implements ConflictResolvedLis
          */
         boolean containsSymlink = false;
         for (final Conflict conflict : conflicts) {
-            if (FileSystemUtils.getInstance().getAttributes(conflict.getTargetLocalItem()).isSymbolicLink()) {
+            if (conflict.getTargetLocalItem() != null
+                && conflict.getTargetLocalItem().length() > 0
+                && FileSystemUtils.getInstance().getAttributes(conflict.getTargetLocalItem()).isSymbolicLink()) {
                 containsSymlink = true;
                 break;
             }


### PR DESCRIPTION
Fixing NullReferenceException error when doing KeepYours and the original file was deleted on the server.