### PR TITLE
242: WorkItemUpdatePackage cannot handle responses with computedColumns without a value

### DIFF
--- a/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/clients/workitem/internal/update/WorkItemUpdatePackage.java
+++ b/source/com.microsoft.tfs.core/src/com/microsoft/tfs/core/clients/workitem/internal/update/WorkItemUpdatePackage.java
@@ -10,6 +10,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
@@ -317,9 +319,7 @@ public class WorkItemUpdatePackage extends BaseUpdatePackage {
                 final Element computedColumnElement = (Element) computedColumns.item(i);
                 final String fieldReferenceName =
                     computedColumnElement.getAttribute(UpdateXMLConstants.ATTRIBUTE_NAME_COLUMN);
-                final String value =
-                    computedColumnElement.getElementsByTagName(UpdateXMLConstants.ELEMENT_NAME_VALUE).item(
-                        0).getChildNodes().item(0).getNodeValue();
+                final String value = getValueOfComputedColumn(computedColumnElement);
 
                 final FieldImpl field = workItem.getFieldsInternal().getFieldInternal(fieldReferenceName);
                 field.setValue(value, FieldModificationType.SERVER);
@@ -339,5 +339,14 @@ public class WorkItemUpdatePackage extends BaseUpdatePackage {
                 handler.handle(element);
             }
         }
+    }
+
+    @Nullable
+    private String getValueOfComputedColumn(final Element computedColumnElement) {
+        NodeList valueElements = computedColumnElement.getElementsByTagName(UpdateXMLConstants.ELEMENT_NAME_VALUE);
+        if (valueElements == null) {
+            return null;
+        }
+        return valueElements.item(0).getChildNodes().item(0).getNodeValue();
     }
 }


### PR DESCRIPTION
Pull request to address https://github.com/Microsoft/team-explorer-everywhere/issues/242

This fix checks for whether there are actual value elements before
proceeding to parse them.
Sadly I was unable to provide a test due to the lack of knowledge on how
to properly mock up the necessary bits needed to instantiate a
WorkItemUpdatePackage. 

Task-Url: https://github.com/Microsoft/team-explorer-everywhere/issues/242