### PR TITLE
Ensure disposal of native auth state after executing Http Method.

### DIFF
--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/HttpMethodDirector.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/HttpMethodDirector.java
@@ -224,6 +224,8 @@ class HttpMethodDirector {
 
             } // end of retry loop
         } finally {
+            cleanupHostAndProxyAuthState(method);
+            
             if (conn != null) {
                 conn.setLocked(false);
             }
@@ -235,6 +237,17 @@ class HttpMethodDirector {
             if ((releaseConnection || method.getResponseBodyAsStream() == null) && conn != null) {
                 conn.releaseConnection();
             }
+        }
+    }
+    
+    private void cleanupHostAndProxyAuthState(final HttpMethod method) {
+        cleanupAuthState(method.getHostAuthState());
+        cleanupAuthState(method.getProxyAuthState());
+    }
+    
+    private void cleanupAuthState(AuthState authState) {
+        if (authState != null) {
+            authState.invalidate();
         }
     }
 

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/AuthScheme.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/AuthScheme.java
@@ -80,6 +80,11 @@ public interface AuthScheme {
     public boolean supportsCredentials(Credentials credentials);
 
     /**
+     * Perform optional cleanup of auth scheme state (e.g. dispose of native OS handles, etc..).
+     */
+    public void cleanup();
+
+    /**
      * Processes the given challenge token. Some authentication schemes may
      * involve multiple challenge-response exchanges. Such schemes must be able
      * to maintain the state information when dealing with sequential challenges

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/AuthState.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/AuthState.java
@@ -76,7 +76,11 @@ public class AuthState {
      * Invalidates the authentication state by resetting its parameters.
      */
     public void invalidate() {
-        authScheme = null;
+        if (authScheme != null) {
+            authScheme.cleanup();
+            authScheme = null;
+        }
+        
         authRequested = false;
         authAttempted = false;
         preemptive = false;
@@ -192,6 +196,10 @@ public class AuthState {
         if (preemptive && !(this.authScheme.getClass().isInstance(authScheme))) {
             preemptive = false;
             authAttempted = false;
+        }
+        
+        if (this.authScheme != null) {
+            this.authScheme.cleanup();
         }
         this.authScheme = authScheme;
     }

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/BasicScheme.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/BasicScheme.java
@@ -253,4 +253,9 @@ public class BasicScheme extends RFC2617Scheme {
             + EncodingUtil.getAsciiString(Base64.encodeBase64(EncodingUtil.getBytes(buffer.toString(), charset)));
     }
 
+    @Override
+    public void cleanup() {
+        
+    }
+
 }

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/CookieAuthScheme.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/CookieAuthScheme.java
@@ -15,6 +15,11 @@ public class CookieAuthScheme implements AuthScheme {
     }
 
     @Override
+    public void cleanup() {
+        //No disposing of credentials needed
+    }
+
+    @Override
     public void processChallenge(final String challenge) throws MalformedChallengeException {
         throw new MalformedChallengeException("Cookie authentication is not challenge/response"); //$NON-NLS-1$
     }

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/DigestScheme.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/DigestScheme.java
@@ -609,4 +609,9 @@ public class DigestScheme extends RFC2617Scheme {
 
         return cnonce;
     }
+
+    @Override
+    public void cleanup() {
+        
+    }
 }

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/JwtAuthScheme.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/JwtAuthScheme.java
@@ -22,6 +22,11 @@ public class JwtAuthScheme extends AuthorizationHeaderScheme {
     }
 
     @Override
+    public void cleanup() {
+        //No disposing of credentials needed
+    }
+
+    @Override
     public void processChallenge(final String challenge) throws MalformedChallengeException {
         complete = true;
     }

--- a/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/NTLMScheme.java
+++ b/source/com.microsoft.tfs.core.httpclient/src/com/microsoft/tfs/core/httpclient/auth/NTLMScheme.java
@@ -70,6 +70,16 @@ public class NTLMScheme extends AuthorizationHeaderScheme implements AuthScheme 
         return supportsCredentials(credentials.getClass());
     }
 
+    @Override
+    public void cleanup() {
+        if(ntlmClient != null) {
+            ntlmClient.dispose();
+            ntlmClient = null;
+        }
+        
+        inputToken = null;
+    }
+
     public static boolean supportsCredentials(final Class<?> credentialClass) {
         if (credentialClass == null || !isSupported()) {
             return false;
@@ -221,11 +231,7 @@ public class NTLMScheme extends AuthorizationHeaderScheme implements AuthScheme 
             if (ntlmClient.isComplete()) {
                 status = STATUS_COMPLETE;
 
-                /* Clean up */
-                ntlmClient.dispose();
-
-                ntlmClient = null;
-                inputToken = null;
+                cleanup();
             } else {
                 status = STATUS_EXCHANGING;
             }


### PR DESCRIPTION
Depending on the selected authorization scheme, it's possible for
some native OS handles to leak once the HttpMethodDirector has
finished executing an HttpMethod. Leaks have been observed for
Kerberos (via SPNEGO - Negotiate) but also seem possible using NTLM
authentication. Examples of potentially leaked handles include:
  * credentials handles (e.g. missing call to FreeCredentialsHandle)
  * security context (e.g. missing call to DeleteSecurityContext)

The HttpMethodDirector now ensures that the selected authorization
scheme has a chance to cleanup outstanding native OS state once the
HttpMethod has finished execution.