### PR TITLE
Added back missing build properties and manifest entries for slf4j.

### DIFF
--- a/source/com.microsoft.tfs.core/META-INF/MANIFEST.MF
+++ b/source/com.microsoft.tfs.core/META-INF/MANIFEST.MF
@@ -27,7 +27,9 @@ Bundle-ClassPath: com.microsoft.tfs.core.jar,
  libs/jna/jna-4.2.1.jar,
  libs/jna/jna-platform-4.2.1.jar,
  libs/jsr305-1.3.9/jsr305-1.3.9.jar,
- libs/oauth2-useragent/oauth2-useragent-0.11.2.jar
+ libs/oauth2-useragent/oauth2-useragent-0.11.2.jar,
+ libs/slf4j/slf4j-api-1.7.19.jar,
+ libs/slf4j/slf4j-log4j12-1.7.19.jar
 Bundle-Vendor: %Bundle-Vendor
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/source/com.microsoft.tfs.core/build.properties
+++ b/source/com.microsoft.tfs.core/build.properties
@@ -25,9 +25,12 @@ bin.includes = META-INF/,\
                libs/jna/jna-4.2.1.jar,\
                libs/jna/jna-platform-4.2.1.jar,\
                libs/jsr305-1.3.9/jsr305-1.3.9.jar,\
-               libs/oauth2-useragent/oauth2-useragent-0.11.2.jar
+               libs/oauth2-useragent/oauth2-useragent-0.11.2.jar,\
+               libs/slf4j/slf4j-api-1.7.19.jar,\
+               libs/slf4j/slf4j-log4j12-1.7.19.jar
 output.com.microsoft.tfs.core.jar = bin/
 source.com.microsoft.tfs.core.jar = src/,\
                                     rest_core/
 
 javacProjectSettings = true
+bin.excludes = libs/slf4j/


### PR DESCRIPTION
For Issue #323 only the libs where added without referencing them in manifest or build properties.